### PR TITLE
Add requeue ability to callbacks feature

### DIFF
--- a/flex-config/ui_attributes.dev.json
+++ b/flex-config/ui_attributes.dev.json
@@ -21,7 +21,9 @@
         }
       },
       "callbacks": {
-        "enabled": true
+        "enabled": true,
+        "allow_requeue": true,
+        "max_attempts": 3
       },
       "caller_id": {
         "enabled": true

--- a/flex-config/ui_attributes.prod.json
+++ b/flex-config/ui_attributes.prod.json
@@ -21,7 +21,9 @@
         }
       },
       "callbacks": {
-        "enabled": true
+        "enabled": true,
+        "allow_requeue": true,
+        "max_attempts": 3
       },
       "caller_id": {
         "enabled": true

--- a/flex-config/ui_attributes.qa.json
+++ b/flex-config/ui_attributes.qa.json
@@ -21,7 +21,9 @@
         }
       },
       "callbacks": {
-        "enabled": true
+        "enabled": true,
+        "allow_requeue": true,
+        "max_attempts": 3
       },
       "caller_id": {
         "enabled": true

--- a/flex-config/ui_attributes.test.json
+++ b/flex-config/ui_attributes.test.json
@@ -21,7 +21,9 @@
         }
       },
       "callbacks": {
-        "enabled": true
+        "enabled": true,
+        "allow_requeue": true,
+        "max_attempts": 3
       },
       "caller_id": {
         "enabled": true

--- a/plugin-flex-ts-template/src/feature-library/callbacks/README.md
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/README.md
@@ -37,7 +37,7 @@ the variable that you need to make sure is set is
 
 The feature works be registering a custom flex channel.  This channel is a presentation only layer, on top of the taskrouter channel, which remains voice.
 
-when the channel is registered, it renders custom components based on the task attribute; _taskType: callbck_
+when the channel is registered, it renders custom components based on the task attribute; _taskType: callback_
 
 there are two associated serverless functions called _create-callback_
 

--- a/plugin-flex-ts-template/src/feature-library/callbacks/README.md
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/README.md
@@ -41,7 +41,7 @@ when the channel is registered, it renders custom components based on the task a
 
 there are two associated serverless functions called _create-callback_
 
-the only difference between these functions is one is intended to be called from flex, the other from anywhere else but typically studio.  The difference is the security model for each function but both do the same thing, taking in task attributes and generating a new callback task.  The flex interface is intended for use, should you wish to introduce a re-queueing feature.
+the only difference between these functions is one is intended to be called from flex, the other from anywhere else but typically studio.  The difference is the security model for each function but both do the same thing, taking in task attributes and generating a new callback task.  The flex interface is used for the re-queueing feature.
 
 
 __

--- a/plugin-flex-ts-template/src/feature-library/callbacks/custom-components/callback/CallbackComponent.tsx
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/custom-components/callback/CallbackComponent.tsx
@@ -9,10 +9,11 @@ import Icon from '@material-ui/core/Icon';
 import styles from './CallbackStyles';
 import { TaskAttributes } from 'types/task-router/Task';
 import { ContainerProps } from './CallbackContainer'
-import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
 export interface OwnProps {
   task: Flex.ITask;
+  allowRequeue: boolean;
+  maxAttempts: number;
 }
 
 export type Props = ContainerProps & OwnProps;
@@ -25,8 +26,6 @@ export default class CallbackComponent extends React.Component<Props> {
     const localTz = moment.tz.guess();
     const localTimeShort = timeReceived.tz(localTz).format('MM-D-YYYY, h:mm:ss a z');
     const serverTimeShort = timeReceived.tz(callBackData?.mainTimeZone || localTz).format('MM-D-YYYY, h:mm:ss a z');
-    const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
-    const { allow_requeue, max_attempts } = custom_data.features.callbacks;
 
     return (
         <span className="Twilio">
@@ -71,7 +70,7 @@ export default class CallbackComponent extends React.Component<Props> {
             <li>&nbsp;</li>
           </ul>
           <Button
-            disabled={taskStatus !== 'assigned'}
+            disabled={taskStatus !== 'assigned' || this.props.isCompletingCallbackAction[this.props.task.taskSid]}
             style={styles.cbButton}
             variant="contained"
             color="primary"
@@ -80,9 +79,9 @@ export default class CallbackComponent extends React.Component<Props> {
             Place Call Now ( {callBackData?.numberToCall} )
           </Button>
           {
-            allow_requeue && (!callBackData.attempts || callBackData.attempts < max_attempts) &&
+            this.props.allowRequeue && (!callBackData.attempts || callBackData.attempts < this.props.maxAttempts) &&
             <Button
-              disabled={taskStatus !== 'assigned'}
+              disabled={taskStatus !== 'assigned' || this.props.isRequeueingCallbackAction[this.props.task.taskSid]}
               style={styles.cbButton}
               variant="contained"
               onClick={async () => this.props.requeueCallback(this.props.task)}

--- a/plugin-flex-ts-template/src/feature-library/callbacks/custom-components/callback/CallbackComponent.tsx
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/custom-components/callback/CallbackComponent.tsx
@@ -25,63 +25,42 @@ export default class CallbackComponent extends React.Component<Props> {
     const timeReceived = moment(callBackData?.utcDateTimeReceived);
     const localTz = moment.tz.guess();
     const localTimeShort = timeReceived.tz(localTz).format('MM-D-YYYY, h:mm:ss a z');
-    const serverTimeShort = timeReceived.tz(callBackData?.mainTimeZone || localTz).format('MM-D-YYYY, h:mm:ss a z');
+    const serverTimeShort = 'System time: ' + timeReceived.tz(callBackData?.mainTimeZone || localTz).format('MM-D-YYYY, h:mm:ss a z');
+    const disableButtons = taskStatus !== 'assigned' || this.props.isCompletingCallbackAction[this.props.task.taskSid] || this.props.isRequeueingCallbackAction[this.props.task.taskSid];
+    const thisAttempt = callBackData?.attempts ? (Number(callBackData.attempts) + 1) : 1
 
     return (
         <span className="Twilio">
-          <h1>Contact CallBack Request</h1>
+          <h1>Contact Callback Request</h1>
           <p>A contact has requested an immediate callback.</p>
-          <h4 style={styles.itemBold}>Callback Details</h4>
-          <ul>
-            <li>
-              <div style={styles.itemWrapper}>
-                <span style={styles.item}>Contact Phone:</span>
-                <span style={styles.itemDetail}>{callBackData?.numberToCall}</span>
-              </div>
-            </li>
-            <li>&nbsp;</li>
-            <li>
-              <div style={styles.itemWrapper}>
-                <span style={styles.itemBold}>Call Reception Information</span>
-              </div>
-            </li>
-            <li>
-              <div style={styles.itemWrapper}>
-                <label style={styles.item}>Received:&nbsp;</label>
-                <Tooltip title="System call reception time" placement="right" >
-                  <Icon color="primary" style={styles.info}>
-                    info
-                  </Icon>
-                </Tooltip>
-                <label style={styles.itemDetail}>{serverTimeShort}</label>
-              </div>
-            </li>
-            <li>
-              <div style={styles.itemWrapper}>
-                <label style={styles.item}>Localized:&nbsp;</label>
-                <Tooltip title="Call time localized to agent" placement="right">
-                  <Icon color="primary" style={styles.info}>
-                    info
-                  </Icon>
-                </Tooltip>
-                <label style={styles.itemDetail}>{localTimeShort}</label>
-              </div>
-            </li>
-            <li>&nbsp;</li>
-          </ul>
+          <h2>Contact phone</h2>
+          <p>{callBackData?.numberToCall}</p>
+          <h2>Call reception time</h2>
+          <p>{localTimeShort}
+            <Tooltip title={serverTimeShort} placement="right" >
+              <Icon color="primary" style={styles.info}>
+                info
+              </Icon>
+            </Tooltip></p>
+          {
+            this.props.allowRequeue &&
+            <><h2>Callback attempt</h2>
+            <p>{thisAttempt} of {this.props.maxAttempts}</p></>
+          }
+          <p></p>
           <Button
-            disabled={taskStatus !== 'assigned' || this.props.isCompletingCallbackAction[this.props.task.taskSid]}
+            disabled={disableButtons}
             style={styles.cbButton}
             variant="contained"
             color="primary"
             onClick={async () => this.props.startCall(this.props.task)}
           >
-            Place Call Now ( {callBackData?.numberToCall} )
+            Place Call Now To {callBackData?.numberToCall}
           </Button>
           {
-            this.props.allowRequeue && (!callBackData.attempts || callBackData.attempts < this.props.maxAttempts) &&
+            this.props.allowRequeue && thisAttempt < this.props.maxAttempts &&
             <Button
-              disabled={taskStatus !== 'assigned' || this.props.isRequeueingCallbackAction[this.props.task.taskSid]}
+              disabled={disableButtons}
               style={styles.cbButton}
               variant="contained"
               onClick={async () => this.props.requeueCallback(this.props.task)}

--- a/plugin-flex-ts-template/src/feature-library/callbacks/custom-components/callback/CallbackContainer.ts
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/custom-components/callback/CallbackContainer.ts
@@ -5,11 +5,10 @@ import { bindActionCreators, Dispatch } from 'redux';
 import { Actions } from '../../flex-hooks/states/callback';
 import CallbackComponent from './CallbackComponent';
 
-const mapStateToProps = (state: AppState) => {
-  return {
-    ...state[reduxNamespace].callback
-  };
-};
+const mapStateToProps = (state: AppState) => ({
+  isCompletingCallbackAction: state[reduxNamespace].callback.isCompletingCallbackAction, 
+  isRequeueingCallbackAction: state[reduxNamespace].callback.isRequeueingCallbackAction
+});
 
 const mapDispatchToProps = (dispatch: Dispatch<Flex.ITask>) => ({
   startCall: bindActionCreators(Actions.callCustomer, dispatch),

--- a/plugin-flex-ts-template/src/feature-library/callbacks/custom-components/callback/CallbackContainer.ts
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/custom-components/callback/CallbackContainer.ts
@@ -1,16 +1,22 @@
 import * as Flex from '@twilio/flex-ui';
 import { connect, ConnectedProps } from 'react-redux'
+import { AppState, reduxNamespace } from '../../../../flex-hooks/states'
 import { bindActionCreators, Dispatch } from 'redux';
 import { Actions } from '../../flex-hooks/states/callback';
 import CallbackComponent from './CallbackComponent';
 
+const mapStateToProps = (state: AppState) => {
+  return {
+    ...state[reduxNamespace].callback
+  };
+};
 
 const mapDispatchToProps = (dispatch: Dispatch<Flex.ITask>) => ({
   startCall: bindActionCreators(Actions.callCustomer, dispatch),
   requeueCallback: bindActionCreators(Actions.requeueCallback, dispatch)
 });
 
-const connector = connect(undefined, mapDispatchToProps);
+const connector = connect(mapStateToProps, mapDispatchToProps);
 
 export type ContainerProps = ConnectedProps<typeof connector>;
 

--- a/plugin-flex-ts-template/src/feature-library/callbacks/custom-components/callback/CallbackContainer.ts
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/custom-components/callback/CallbackContainer.ts
@@ -6,7 +6,8 @@ import CallbackComponent from './CallbackComponent';
 
 
 const mapDispatchToProps = (dispatch: Dispatch<Flex.ITask>) => ({
-  startCall: bindActionCreators(Actions.callCustomer, dispatch)
+  startCall: bindActionCreators(Actions.callCustomer, dispatch),
+  requeueCallback: bindActionCreators(Actions.requeueCallback, dispatch)
 });
 
 const connector = connect(undefined, mapDispatchToProps);

--- a/plugin-flex-ts-template/src/feature-library/callbacks/custom-components/callback/CallbackStyles.ts
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/custom-components/callback/CallbackStyles.ts
@@ -1,21 +1,12 @@
 export default {
-  itemWrapper: {
-    width: '100%',
-  },
-  itemBold: { fontWeight: 'bold' },
-  item: {
-    width: 100,
-  },
-  itemDetail: {
-  },
   cbButton: {
     width: '100%',
     marginBottom: '10px',
     fontSize: '10pt',
   },
-  textCenter: {
-    textAlign: 'center',
-    color: 'blue',
+  info: {
+    verticalAlign: 'middle',
+    fontSize: '13px',
+    margin: '0 5px'
   },
-  info: { top: '3px' },
 };

--- a/plugin-flex-ts-template/src/feature-library/callbacks/custom-components/callback/CallbackStyles.ts
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/custom-components/callback/CallbackStyles.ts
@@ -10,7 +10,7 @@ export default {
   },
   cbButton: {
     width: '100%',
-    marginBottom: '5px',
+    marginBottom: '10px',
     fontSize: '10pt',
   },
   textCenter: {

--- a/plugin-flex-ts-template/src/feature-library/callbacks/flex-hooks/components/TaskInfoPanel.tsx
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/flex-hooks/components/TaskInfoPanel.tsx
@@ -3,13 +3,13 @@ import CallbackComponent from '../../custom-components/callback'
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
 const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
-const { enabled } = custom_data.features.callbacks;
+const { enabled, allow_requeue, max_attempts } = custom_data.features.callbacks;
 
 export function replaceViewForCallbacks(flex: typeof Flex, manager: Flex.Manager) {
   
   if(!enabled) return;
 
-  Flex.TaskInfoPanel.Content.replace(<CallbackComponent key="callback-component" manager={manager} />, {
+  Flex.TaskInfoPanel.Content.replace(<CallbackComponent key="callback-component" allowRequeue={allow_requeue} maxAttempts={max_attempts} />, {
     sortOrder: -1,
     if: (props) => props.task.attributes.taskType === 'callback',
   });

--- a/plugin-flex-ts-template/src/feature-library/callbacks/flex-hooks/states/callback/actions.ts
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/flex-hooks/states/callback/actions.ts
@@ -1,7 +1,7 @@
 import * as Flex from '@twilio/flex-ui';
 import { Action } from '../../../../../flex-hooks/states'
 import CallbackService from '../../../utils/callback/CallbackService'
-import { INITIATE_CALLBACK } from './types';
+import { INITIATE_CALLBACK, REQUEUE_CALLBACK } from './types';
 
 
 // Provide task to "pending" action as payload
@@ -14,6 +14,16 @@ class Actions {
       type: INITIATE_CALLBACK,
       payload: {
         promise: CallbackService.callCustomerBack(task, 0),
+        data: task
+      }
+    };
+  };
+  
+  public static requeueCallback = (task: Flex.ITask): Action => {
+    return {
+      type: REQUEUE_CALLBACK,
+      payload: {
+        promise: CallbackService.requeueCallback(task),
         data: task
       }
     };

--- a/plugin-flex-ts-template/src/feature-library/callbacks/flex-hooks/states/callback/initialState.ts
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/flex-hooks/states/callback/initialState.ts
@@ -2,6 +2,7 @@ import { CallbackState } from './types';
 
 const initialState: CallbackState = {
   isCompletingCallbackAction: {},
+  isRequeueingCallbackAction: {}
 };
 
 export default initialState;

--- a/plugin-flex-ts-template/src/feature-library/callbacks/flex-hooks/states/callback/reducer.ts
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/flex-hooks/states/callback/reducer.ts
@@ -1,6 +1,6 @@
 import * as Flex from '@twilio/flex-ui';
 import { Action } from '../../../../../flex-hooks/states'
-import { CallbackState, INITIATE_CALLBACK } from './types';
+import { CallbackState, INITIATE_CALLBACK, REQUEUE_CALLBACK } from './types';
 
 import initialState from './initialState';
 
@@ -29,6 +29,30 @@ export default function (state = initialState, action: Action): CallbackState {
       return {
         ...state,
         isCompletingCallbackAction
+      };
+    }
+    
+    case `${REQUEUE_CALLBACK}_PENDING`: {
+      const { taskSid } = action.payload as Flex.ITask;
+      return {
+        ...state,
+        isRequeueingCallbackAction: {
+          ...state.isRequeueingCallbackAction,
+          [taskSid]: true
+        }
+      };
+    }
+    
+    case `${REQUEUE_CALLBACK}_REJECTED`:
+    
+    case `${REQUEUE_CALLBACK}_FULFILLED`: {
+      const { taskSid } = action.payload as Flex.ITask;
+      const isRequeueingCallbackAction = state.isRequeueingCallbackAction;
+      delete isRequeueingCallbackAction[taskSid];
+    
+      return {
+        ...state,
+        isRequeueingCallbackAction
       };
     }
 

--- a/plugin-flex-ts-template/src/feature-library/callbacks/flex-hooks/states/callback/reducer.ts
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/flex-hooks/states/callback/reducer.ts
@@ -23,7 +23,7 @@ export default function (state = initialState, action: Action): CallbackState {
 
     case `${INITIATE_CALLBACK}_FULFILLED`: {
       const { taskSid } = action.payload as Flex.ITask;
-      const isCompletingCallbackAction = state.isCompletingCallbackAction;
+      const isCompletingCallbackAction = {...state.isCompletingCallbackAction};
       delete isCompletingCallbackAction[taskSid];
 
       return {
@@ -47,7 +47,7 @@ export default function (state = initialState, action: Action): CallbackState {
     
     case `${REQUEUE_CALLBACK}_FULFILLED`: {
       const { taskSid } = action.payload as Flex.ITask;
-      const isRequeueingCallbackAction = state.isRequeueingCallbackAction;
+      const isRequeueingCallbackAction = {...state.isRequeueingCallbackAction};
       delete isRequeueingCallbackAction[taskSid];
     
       return {

--- a/plugin-flex-ts-template/src/feature-library/callbacks/flex-hooks/states/callback/types.ts
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/flex-hooks/states/callback/types.ts
@@ -1,8 +1,10 @@
 // Actions
 export const prefix = 'custom/Callback';
 export const INITIATE_CALLBACK = `${prefix}/INITIATE_CALLBACK`;
+export const REQUEUE_CALLBACK = `${prefix}/REQUEUE_CALLBACK`;
 
 // State
 export interface CallbackState {
 	isCompletingCallbackAction: { [taskSid: string]: boolean; };
+	isRequeueingCallbackAction: { [taskSid: string]: boolean; };
 };

--- a/plugin-flex-ts-template/src/feature-library/callbacks/utils/callback/CallbackService.ts
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/utils/callback/CallbackService.ts
@@ -84,7 +84,7 @@ class CallbackService extends ApiService {
     return task;
   }
   
-  async requeueCallback(task: Flex.ITask): Promise<Boolean> {
+  async requeueCallback(task: Flex.ITask): Promise<Flex.ITask> {
     let request: CreateCallbackRequest = {
       numberToCall: task.attributes.callBackData.numberToCall,
       numberToCallFrom: task.attributes.callBackData.numberToCallFrom,
@@ -102,12 +102,13 @@ class CallbackService extends ApiService {
       let response = await this.#createCallback(request);
       
       if (response.success) {
-        await Flex.Actions.invokeAction("WrapupTask", { sid: task.sid });
+        await Flex.Actions.invokeAction("WrapupTask", { task });
       }
       
-      return response.success;
+      return task;
     } catch (error) {
-      return false;
+      console.log('Unable to requeue callback', error);
+      return Promise.reject(task);
     }
   }
   

--- a/plugin-flex-ts-template/src/feature-library/callbacks/utils/callback/CallbackService.ts
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/utils/callback/CallbackService.ts
@@ -85,31 +85,30 @@ class CallbackService extends ApiService {
   }
   
   async requeueCallback(task: Flex.ITask): Promise<Flex.ITask> {
-    let request: CreateCallbackRequest = {
-      numberToCall: task.attributes.callBackData.numberToCall,
-      numberToCallFrom: task.attributes.callBackData.numberToCallFrom,
-      flexFlowSid: task.attributes.flow_execution_sid,
-      workflowSid: task.workflowSid,
-      timeout: task.timeout,
-      priority: task.priority,
-      attempts: task.attributes.callBackData.attempts + 1,
-      conversation_id: task.sid,
-      message: task.attributes.message,
-      utcDateTimeReceived: task.attributes.callBackData.utcDateTimeReceived
-    }
-    
     try {
+      let request: CreateCallbackRequest = {
+        numberToCall: task.attributes.callBackData.numberToCall,
+        numberToCallFrom: task.attributes.callBackData.numberToCallFrom,
+        flexFlowSid: task.attributes.flow_execution_sid,
+        workflowSid: task.workflowSid,
+        timeout: task.timeout,
+        priority: task.priority,
+        attempts: task.attributes.callBackData.attempts ? Number(task.attributes.callBackData.attempts) + 1 : 1,
+        conversation_id: task.taskSid,
+        message: task.attributes.message,
+        utcDateTimeReceived: task.attributes.callBackData.utcDateTimeReceived ? task.attributes.callBackData.utcDateTimeReceived : new Date()
+      }
+      
       let response = await this.#createCallback(request);
       
       if (response.success) {
         await Flex.Actions.invokeAction("WrapupTask", { task });
       }
-      
-      return task;
     } catch (error) {
       console.log('Unable to requeue callback', error);
-      return Promise.reject(task);
     }
+    
+    return task;
   }
   
   #createCallback = async (request: CreateCallbackRequest): Promise<CreateCallbackResponse> => {

--- a/plugin-flex-ts-template/src/feature-library/callbacks/utils/callback/CallbackService.ts
+++ b/plugin-flex-ts-template/src/feature-library/callbacks/utils/callback/CallbackService.ts
@@ -1,7 +1,28 @@
 import * as Flex from '@twilio/flex-ui';
 import ApiService from '../../../../utils/serverless/ApiService';
+import { EncodedParams } from '../../../../types/serverless';
 import { TaskAttributes } from '../../../../types/task-router/Task';
 import { CallbackNotification } from '../../flex-hooks/notifications/Callback';
+
+export interface CreateCallbackResponse {
+  success: boolean,
+  taskSid: string,
+  data: string,
+  message: string
+}
+
+export interface CreateCallbackRequest {
+  numberToCall: string,
+  numberToCallFrom: string,
+  flexFlowSid: string,
+  workflowSid?: string,
+  timeout?: number,
+  priority?: number,
+  attempts?: number,
+  conversation_id?: string,
+  message?: string,
+  utcDateTimeReceived?: Date
+};
 
 class CallbackService extends ApiService {
 
@@ -62,6 +83,60 @@ class CallbackService extends ApiService {
     }
     return task;
   }
+  
+  async requeueCallback(task: Flex.ITask): Promise<Boolean> {
+    let request: CreateCallbackRequest = {
+      numberToCall: task.attributes.callBackData.numberToCall,
+      numberToCallFrom: task.attributes.callBackData.numberToCallFrom,
+      flexFlowSid: task.attributes.flow_execution_sid,
+      workflowSid: task.workflowSid,
+      timeout: task.timeout,
+      priority: task.priority,
+      attempts: task.attributes.callBackData.attempts + 1,
+      conversation_id: task.sid,
+      message: task.attributes.message,
+      utcDateTimeReceived: task.attributes.callBackData.utcDateTimeReceived
+    }
+    
+    try {
+      let response = await this.#createCallback(request);
+      
+      if (response.success) {
+        await Flex.Actions.invokeAction("WrapupTask", { sid: task.sid });
+      }
+      
+      return response.success;
+    } catch (error) {
+      return false;
+    }
+  }
+  
+  #createCallback = async (request: CreateCallbackRequest): Promise<CreateCallbackResponse> => {
+    const encodedParams: EncodedParams = {
+      Token: encodeURIComponent(this.manager.user.token),
+      numberToCall: encodeURIComponent(request.numberToCall),
+      numberToCallFrom: encodeURIComponent(request.numberToCallFrom),
+      flexFlowSid: encodeURIComponent(request.numberToCallFrom),
+      workflowSid: request.workflowSid ? encodeURIComponent(request.workflowSid) : undefined,
+      timeout: request.timeout ? encodeURIComponent(request.timeout) : undefined,
+      priority: request.priority ? encodeURIComponent(request.priority) : undefined,
+      attempts: request.attempts ? encodeURIComponent(request.attempts) : undefined,
+      conversation_id: request.conversation_id ? encodeURIComponent(request.conversation_id) : undefined,
+      message: request.message ? encodeURIComponent(request.message) : undefined,
+      utcDateTimeReceived: request.utcDateTimeReceived ? encodeURIComponent(request.utcDateTimeReceived.toString()) : undefined,
+    };
+  
+    const response = await this.fetchJsonWithReject<CreateCallbackResponse>(
+          `https://${this.serverlessDomain}/functions/features/callbacks/flex/create-callback`,
+          {
+              method: 'post',
+              headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+              body: this.buildBody(encodedParams)
+          }
+      );
+    
+    return response;
+  };
 }
 
 export default new CallbackService();

--- a/plugin-flex-ts-template/src/types/manager/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template/src/types/manager/ServiceConfiguration.ts
@@ -23,7 +23,9 @@ export interface UIAttributes extends FlexUIAttributes {
         rules: ActivitySkillFilterRules
       },
       callbacks: {
-        enabled: boolean
+        enabled: boolean,
+        allow_requeue: boolean,
+        max_attempts: number
       },
       caller_id: {
         enabled: boolean

--- a/serverless-functions/src/functions/features/callbacks/flex/create-callback.js
+++ b/serverless-functions/src/functions/features/callbacks/flex/create-callback.js
@@ -1,3 +1,4 @@
+const TokenValidator = require('twilio-flex-token-validator').functionValidator;
 const ParameterValidator = require(Runtime.getFunctions()['functions/common/helpers/parameter-validator'].path);
 const TaskOperations = require(Runtime.getFunctions()['functions/common/twilio-wrappers/taskrouter'].path);
 
@@ -39,6 +40,7 @@ exports.handler = TokenValidator(async function createCallbackFlex(context, even
         attempts: retryAttempt,
         conversation_id,
         message,
+        utcDateTimeReceived
       } = event;
 
       // use assigned values or use defaults
@@ -58,7 +60,7 @@ exports.handler = TokenValidator(async function createCallbackFlex(context, even
           numberToCallFrom,
           attempts,
           mainTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-          utcDateTimeReceived: new Date()
+          utcDateTimeReceived: utcDateTimeReceived || new Date()
         },
         direction: "inbound",
         conversations: {


### PR DESCRIPTION
- Added options to config: allow_requeue, max_attempts
- Modified callback task info pane:
  - Simplified layout, made consistent with out-of-box component
  - Disabled buttons when the task isn't assigned, or if there are pending promises
  - Added attempts counter
  - Added 'retry later' button to requeue the callback & wrap the current task
- Fixed `create-callback` serverless function and added parameter to maintain the original request date/time during a requeue

![Screen Shot 2022-07-15 at 2 22 50 PM](https://user-images.githubusercontent.com/7373633/179296716-f08da7c3-150f-4104-a637-9e7fbe96a9f7.png)